### PR TITLE
Add config option to hide empty comments message

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ directive = End each reply with \"Hope this helps!\"
   logged even if their level is above the current setting. This is useful for debugging without the need to set the
   overall log level to DEBUG, which could result in excessive DEBUG messages from sources like gerrit and other plugins.
   Some usage examples can be found at [Selective Log Level Override](#selective-log-level-override) section.
+- `hideEmptyCommentsMessage`: Initially set to false, this options disables a comment from the plugin if no updates
+  are being made by the plugin, the empty comments system message.
 
 ### Optional Parameters Specific to Stateless Mode
 

--- a/src/main/java/com/googlesource/gerrit/plugins/chatgpt/config/Configuration.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/chatgpt/config/Configuration.java
@@ -92,6 +92,7 @@ public class Configuration extends ConfigCore {
     private static final int DEFAULT_GPT_UPLOADED_CHUNK_SIZE_MB = 5;
     private static final boolean DEFAULT_ENABLE_MESSAGE_DEBUGGING = false;
     private static final List<String> DEFAULT_SELECTIVE_LOG_LEVEL_OVERRIDE = new ArrayList<>();
+    private static final boolean DEFAULT_HIDE_EMPTY_COMMENTS_MESSAGE = false;
 
     // Config setting keys
     public static final String KEY_GPT_SYSTEM_PROMPT_INSTRUCTIONS = "gptSystemPromptInstructions";
@@ -150,6 +151,7 @@ public class Configuration extends ConfigCore {
     private static final String KEY_GPT_POLLING_INTERVAL = "gptPollingInterval";
     private static final String KEY_GPT_UPLOADED_CHUNK_SIZE_MB = "gptUploadedChunkSizeMb";
     private static final String KEY_ENABLE_MESSAGE_DEBUGGING = "enableMessageDebugging";
+    private static final String KEY_HIDE_EMPTY_COMMENTS_MESSAGE = "hideEmptyCommentsMessage";
 
     public Configuration(
             OneOffRequestContext context,
@@ -364,6 +366,10 @@ public class Configuration extends ConfigCore {
 
     public List<String> getSelectiveLogLevelOverride() {
         return splitListIntoItems(KEY_SELECTIVE_LOG_LEVEL_OVERRIDE, DEFAULT_SELECTIVE_LOG_LEVEL_OVERRIDE);
+    }
+
+    public boolean getHideEmptyCommentsMessage() {
+        return getBoolean(KEY_HIDE_EMPTY_COMMENTS_MESSAGE, DEFAULT_HIDE_EMPTY_COMMENTS_MESSAGE);
     }
 
     public boolean isDefinedKey(String key) {

--- a/src/main/java/com/googlesource/gerrit/plugins/chatgpt/mode/common/client/api/gerrit/GerritClientReview.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/chatgpt/mode/common/client/api/gerrit/GerritClientReview.java
@@ -129,7 +129,7 @@ public class GerritClientReview extends GerritClientAccount {
                 messages.add(debugCodeBlocksDynamicConfiguration.getDebugCodeBlock(dynamicConfig));
             }
         }
-        if (emptyComments) {
+        if (emptyComments && !config.getHideEmptyCommentsMessage()) {
             messages.add(localizer.getText("system.message.prefix") + ' ' + systemMessage);
         }
         errorMessageHandler.updateErrorMessages(messages);

--- a/src/test/resources/__files/commands/dumpConfig.txt
+++ b/src/test/resources/__files/commands/dumpConfig.txt
@@ -67,6 +67,7 @@ gptReviewTemperature: 0.2
 gptStreamOutput: false
 gptSystemPromptInstructions: Act as a PatchSet Reviewer
 gptUploadedChunkSizeMb: 5
+hideEmptyCommentsMessage: false
 ignoreOutdatedInlineComments: false
 ignoreResolvedChatGptComments: true
 inlineCommentsAsResolved: false


### PR DESCRIPTION
Adds a configuration item that allows users to
disable the message that gets added when there
are no comments from ChatGPT on the change.

  SYSTEM MESSAGE: No update to show for this Change Set