### PR TITLE
[codex generated] retry without conversationID on ZDR error

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/client/api/LangChainClient.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/client/api/LangChainClient.java
@@ -19,6 +19,7 @@ package com.googlesource.gerrit.plugins.reviewai.aibackend.langchain.client.api;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.openai.errors.OpenAIServiceException;
 import com.googlesource.gerrit.plugins.reviewai.aibackend.common.client.api.ai.AiClientBase;
 import com.googlesource.gerrit.plugins.reviewai.aibackend.common.client.api.gerrit.GerritChange;
 import com.googlesource.gerrit.plugins.reviewai.aibackend.common.client.api.gerrit.GerritClient;
@@ -51,6 +52,7 @@ import dev.langchain4j.memory.chat.TokenWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import java.util.List;
+import java.util.Locale;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -89,6 +91,7 @@ public class LangChainClient extends AiClientBase implements IAiClient {
   }
 
   protected record ConversationResolution(String conversationId, boolean existingConversation) {}
+  protected record ExecutionOutcome(AiMessage aiMessage, ChatMemory memory) {}
 
   @Inject
   public LangChainClient(
@@ -179,7 +182,7 @@ public class LangChainClient extends AiClientBase implements IAiClient {
       log.info("LangChain user prompt for {}: {}", memoryId, userMessage);
 
       ChatMemory memory =
-          providerType == AiProviderType.OPENAI ? buildTransientMemory(memoryId) : buildMemory(memoryId);
+          createMemory(providerType, conversationResolution.conversationId(), memoryId);
       boolean hasStoredMemory = !memory.messages().isEmpty();
 
       if (!hasStoredMemory && providerType != AiProviderType.OPENAI) {
@@ -226,7 +229,21 @@ public class LangChainClient extends AiClientBase implements IAiClient {
           memorySnapshot.size(),
           memorySnapshot);
 
-      AiMessage ai = toolExecutor.execute(model, change, memory);
+      ExecutionOutcome executionOutcome =
+          executeWithConversationFallback(
+              providerType,
+              conversationResolution.conversationId(),
+              changeSetData,
+              change,
+              memory,
+              provider,
+              temperature,
+              systemInstructions,
+              memoryId,
+              model,
+              providerModel.getEndpoint());
+      ChatMemory memoryForResponse = executionOutcome.memory();
+      AiMessage ai = executionOutcome.aiMessage();
       String responseText = ai != null ? ai.text() : null;
 
       if (responseText == null) {
@@ -237,7 +254,7 @@ public class LangChainClient extends AiClientBase implements IAiClient {
       if (ai.hasToolExecutionRequests()) {
         log.warn("Skipping final LangChain memory update because response still has tool requests");
       } else {
-        memory.add(ai);
+        memoryForResponse.add(ai);
       }
 
       return new ReviewRequestResult(toResponseContent(responseText), userMessage);
@@ -280,24 +297,156 @@ public class LangChainClient extends AiClientBase implements IAiClient {
     if (providerType != AiProviderType.OPENAI || pluginDataHandlerProvider == null) {
       return new ConversationResolution(null, false);
     }
-    String conversationKey = OpenAiConversation.KEY_CONVERSATION_ID;
-    if (changeSetData.getReviewAssistantStage() != null) {
-      switch (changeSetData.getReviewAssistantStage()) {
-        case REVIEW_CODE:
-        case REVIEW_COMMIT_MESSAGE:
-          conversationKey =
-              OpenAiConversation.getMultiAgentConversationKey(
-                  changeSetData.getReviewAssistantStage());
-          break;
-        default:
-          break;
-      }
-    }
+    String conversationKey = getConversationStorageKey(changeSetData);
     OpenAiConversation conversation =
         new OpenAiConversation(config, pluginDataHandlerProvider, conversationKey);
     boolean existingConversation = conversation.hasExistingConversation();
     return new ConversationResolution(
         conversation.resolveConversationId(), existingConversation);
+  }
+
+  protected String getConversationStorageKey(ChangeSetData changeSetData) {
+    String conversationKey = OpenAiConversation.KEY_CONVERSATION_ID;
+    if (changeSetData.getReviewAssistantStage() == null) {
+      return conversationKey;
+    }
+    switch (changeSetData.getReviewAssistantStage()) {
+      case REVIEW_CODE:
+      case REVIEW_COMMIT_MESSAGE:
+        return OpenAiConversation.getMultiAgentConversationKey(
+            changeSetData.getReviewAssistantStage());
+      default:
+        return conversationKey;
+    }
+  }
+
+  protected ExecutionOutcome executeWithConversationFallback(
+      AiProviderType providerType,
+      String conversationId,
+      ChangeSetData changeSetData,
+      GerritChange change,
+      ChatMemory memory,
+      ILangChainProvider provider,
+      double temperature,
+      String systemInstructions,
+      Object memoryId,
+      ChatModel model,
+      String endpoint) {
+    try {
+      return new ExecutionOutcome(toolExecutor.execute(model, change, memory), memory);
+    } catch (RuntimeException e) {
+      if (!shouldRetryWithoutConversation(providerType, conversationId, e)) {
+        throw e;
+      }
+      log.warn(
+          "OpenAI rejected conversation parameter for {} (conversationId={}); retrying once "
+              + "without conversation and persisting local memory mode for this Change Set",
+          memoryId,
+          conversationId,
+          e);
+      clearResolvedConversationId(changeSetData);
+      LangChainProvider retryProviderModel =
+          provider.buildChatModel(config, temperature, null, systemInstructions);
+      ChatMemory retryMemory = createMemory(providerType, null, memoryId);
+      if (retryMemory.messages().isEmpty()) {
+        for (ChatMessage message : memory.messages()) {
+          retryMemory.add(message);
+        }
+      }
+      log.info(
+          "Retrying LangChain request for {} using provider {} model {} "
+              + "(temperature={}, endpoint={})",
+          memoryId,
+          providerType,
+          config.getAiModel(),
+          temperature,
+          retryProviderModel.getEndpoint() == null ? endpoint : retryProviderModel.getEndpoint());
+      return new ExecutionOutcome(
+          toolExecutor.execute(retryProviderModel.getModel(), change, retryMemory), retryMemory);
+    }
+  }
+
+  protected boolean shouldRetryWithoutConversation(
+      AiProviderType providerType, String conversationId, Throwable throwable) {
+    if (providerType != AiProviderType.OPENAI
+        || conversationId == null
+        || conversationId.isBlank()
+        || throwable == null) {
+      return false;
+    }
+    OpenAIServiceException openAiException = findOpenAiServiceException(throwable);
+    if (openAiException != null) {
+      String param = openAiException.param().orElse("");
+      String code = openAiException.code().orElse("");
+      String body = String.valueOf(openAiException.body()).toLowerCase(Locale.ROOT);
+      if ("conversation".equalsIgnoreCase(param)
+          && ("unsupported_parameter".equalsIgnoreCase(code)
+              || body.contains("zero data retention"))) {
+        return true;
+      }
+    }
+    String message = flattenMessages(throwable).toLowerCase(Locale.ROOT);
+    return message.contains("param=conversation")
+        && (message.contains("unsupported_parameter")
+            || message.contains("zero data retention"));
+  }
+
+  protected void clearResolvedConversationId(ChangeSetData changeSetData) {
+    if (pluginDataHandlerProvider == null) {
+      return;
+    }
+    OpenAiConversation conversation =
+        new OpenAiConversation(
+            config, pluginDataHandlerProvider, getConversationStorageKey(changeSetData));
+    try {
+      conversation.setConversationDisabled(true);
+      pluginDataHandlerProvider
+          .getChangeScope()
+          .removeValue(getConversationStorageKey(changeSetData));
+    } catch (RuntimeException e) {
+      log.warn(
+          "Failed to switch OpenAI conversation mode to local memory for key {}",
+          getConversationStorageKey(changeSetData),
+          e);
+    }
+  }
+
+  protected ChatMemory createMemory(
+      AiProviderType providerType, String conversationId, Object memoryId) {
+    if (providerType != AiProviderType.OPENAI) {
+      return buildMemory(memoryId);
+    }
+    if (conversationId == null || conversationId.isBlank()) {
+      return buildMemory(memoryId);
+    }
+    return buildTransientMemory(memoryId);
+  }
+
+  private OpenAIServiceException findOpenAiServiceException(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof OpenAIServiceException serviceException) {
+        return serviceException;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private String flattenMessages(Throwable throwable) {
+    StringBuilder builder = new StringBuilder();
+    Throwable current = throwable;
+    while (current != null) {
+      String message = current.getMessage();
+      if (message != null && !message.isBlank()) {
+        if (!builder.isEmpty()) {
+          builder.append(" | ");
+        }
+        builder.append(message);
+      }
+      current = current.getCause();
+    }
+    return builder.toString();
   }
 
   @VisibleForTesting

--- a/src/main/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/provider/openai/OpenAiConversation.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/provider/openai/OpenAiConversation.java
@@ -34,6 +34,7 @@ import static com.googlesource.gerrit.plugins.reviewai.utils.GsonUtils.jsonToCla
 @Slf4j
 public class OpenAiConversation {
   public static final String KEY_CONVERSATION_ID = "conversationId";
+  public static final String KEY_CONVERSATION_DISABLED = "conversationDisabled";
 
   private final Configuration config;
   private final PluginDataHandler changeDataHandler;
@@ -59,6 +60,10 @@ public class OpenAiConversation {
   }
 
   public String resolveConversationId() throws AiConnectionFailException {
+    if (isConversationDisabled()) {
+      log.info("OpenAI conversation support disabled for this Change Set; using local memory only");
+      return null;
+    }
     String conversationId = getExistingConversationId();
     if (conversationId == null) {
       return createConversation();
@@ -70,7 +75,22 @@ public class OpenAiConversation {
   }
 
   public boolean hasExistingConversation() {
+    if (isConversationDisabled()) {
+      return false;
+    }
     return getExistingConversationId() != null;
+  }
+
+  public boolean isConversationDisabled() {
+    return Boolean.parseBoolean(changeDataHandler.getValue(KEY_CONVERSATION_DISABLED));
+  }
+
+  public void setConversationDisabled(boolean disabled) {
+    if (disabled) {
+      changeDataHandler.setValue(KEY_CONVERSATION_DISABLED, Boolean.TRUE.toString());
+      return;
+    }
+    changeDataHandler.removeValue(KEY_CONVERSATION_DISABLED);
   }
 
   private String getExistingConversationId() {
@@ -109,6 +129,7 @@ public class OpenAiConversation {
 
   public void clear() {
     changeDataHandler.removeValue(KEY_CONVERSATION_ID);
+    changeDataHandler.removeValue(KEY_CONVERSATION_DISABLED);
     for (ReviewAssistantStage assistantStage : ReviewAssistantStage.values()) {
       changeDataHandler.removeValue(getMultiAgentConversationKey(assistantStage));
     }

--- a/src/main/java/com/googlesource/gerrit/plugins/reviewai/data/ReviewAiDb.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/reviewai/data/ReviewAiDb.java
@@ -21,29 +21,24 @@ import static com.googlesource.gerrit.plugins.reviewai.utils.JdbcUtils.hasColumn
 import com.google.gerrit.extensions.annotations.PluginData;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.h2.tools.Server;
+import lombok.extern.slf4j.Slf4j;
 
 @Singleton
+@Slf4j
 public class ReviewAiDb {
   private static final String DB_FILE_NAME = "reviewai";
-  private static final String TCP_HOST = "localhost";
-  private static final int TCP_PORT = 9092;
-  private static final String TCP_URL_PREFIX = "jdbc:h2:tcp://" + TCP_HOST + ":" + TCP_PORT + "/";
-  private static final Object TCP_SERVER_LOCK = new Object();
-
-  private static Server tcpServer;
 
   private final Path pluginDataDir;
   private final String jdbcUrl;
+  private volatile boolean connectionInfoLogged;
 
   @Inject
   public ReviewAiDb(@PluginData Path pluginDataDir) throws IOException {
@@ -54,12 +49,12 @@ public class ReviewAiDb {
     Files.createDirectories(pluginDataDir);
     this.pluginDataDir = pluginDataDir;
     this.jdbcUrl = jdbcUrl;
-    ensureTcpServerStarted();
   }
 
   public static String buildJdbcUrl(Path pluginDataDir) {
-    Path dbFile = pluginDataDir.resolve(DB_FILE_NAME).toAbsolutePath();
-    return TCP_URL_PREFIX + dbFile + ";AUTO_SERVER=FALSE;DB_CLOSE_DELAY=-1";
+    Path dbFile = pluginDataDir.resolve(DB_FILE_NAME).toAbsolutePath().normalize();
+    // Match Gerrit's embedded-H2 style: use an on-disk DB URL, no dedicated H2 TCP server.
+    return "jdbc:h2:" + dbFile.toUri() + ";AUTO_SERVER=FALSE;DB_CLOSE_DELAY=-1";
   }
 
   public Path getPluginDataDir() {
@@ -67,8 +62,28 @@ public class ReviewAiDb {
   }
 
   public Connection getConnection() throws SQLException {
-    ensureTcpServerStarted();
-    return DriverManager.getConnection(jdbcUrl);
+    Path dbFilePath = pluginDataDir.resolve(DB_FILE_NAME + ".mv.db").toAbsolutePath().normalize();
+    boolean dbFileExistedBeforeConnect = Files.exists(dbFilePath);
+    if (!connectionInfoLogged) {
+      log.info(
+          "Opening ReviewAI DB connection: jdbcUrl='{}', pluginDataDir='{}', dbFile='{}', "
+              + "dbFileExistedBeforeConnect={}",
+          jdbcUrl,
+          pluginDataDir.toAbsolutePath().normalize(),
+          dbFilePath,
+          dbFileExistedBeforeConnect);
+    }
+    Connection connection = DriverManager.getConnection(jdbcUrl);
+    if (!connectionInfoLogged) {
+      boolean dbFileExistsAfterConnect = Files.exists(dbFilePath);
+      log.info(
+          "ReviewAI DB connection opened: dbFile='{}', dbFileExistsAfterConnect={}, dbFileSizeBytes={}",
+          dbFilePath,
+          dbFileExistsAfterConnect,
+          dbFileExistsAfterConnect ? new File(dbFilePath.toString()).length() : 0);
+      connectionInfoLogged = true;
+    }
+    return connection;
   }
 
   public <T> T withConnection(ConnectionCallback<T> callback) throws SQLException {
@@ -164,38 +179,6 @@ public class ReviewAiDb {
           }
           return null;
         });
-  }
-
-  private void ensureTcpServerStarted() {
-    if (!usesManagedTcpServer()) {
-      return;
-    }
-    synchronized (TCP_SERVER_LOCK) {
-      if ((tcpServer != null && tcpServer.isRunning(false)) || isTcpServerAvailable()) {
-        return;
-      }
-      try {
-        tcpServer =
-            Server.createTcpServer(
-                    "-tcpPort", Integer.toString(TCP_PORT), "-tcpDaemon", "-ifNotExists")
-                .start();
-      } catch (SQLException e) {
-        throw new RuntimeException("Failed to start H2 TCP server for ReviewAI DB", e);
-      }
-    }
-  }
-
-  private boolean usesManagedTcpServer() {
-    return jdbcUrl.startsWith(TCP_URL_PREFIX);
-  }
-
-  private static boolean isTcpServerAvailable() {
-    try (Socket socket = new Socket()) {
-      socket.connect(new InetSocketAddress(TCP_HOST, TCP_PORT), 200);
-      return true;
-    } catch (IOException e) {
-      return false;
-    }
   }
 
   @FunctionalInterface

--- a/src/test/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/LangChainClientTest.java
+++ b/src/test/java/com/googlesource/gerrit/plugins/reviewai/aibackend/langchain/LangChainClientTest.java
@@ -17,6 +17,7 @@
 package com.googlesource.gerrit.plugins.reviewai.aibackend.langchain;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -124,6 +125,8 @@ public class LangChainClientTest {
   @Test
   public void resolvesOpenAiConversationForLangChainOpenAiProvider() throws Exception {
     PluginDataHandler changeDataHandler = Mockito.mock(PluginDataHandler.class);
+    when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_DISABLED))
+        .thenReturn("false");
     when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_ID))
         .thenReturn("conv_langchain_openai");
     PluginDataHandlerProvider pluginDataHandlerProvider = Mockito.mock(PluginDataHandlerProvider.class);
@@ -145,6 +148,8 @@ public class LangChainClientTest {
   @Test
   public void resolvesOpenAiConversationForNormalFollowUpMessage() throws Exception {
     PluginDataHandler changeDataHandler = Mockito.mock(PluginDataHandler.class);
+    when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_DISABLED))
+        .thenReturn("false");
     when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_ID))
         .thenReturn("conv_follow_up");
     PluginDataHandlerProvider pluginDataHandlerProvider = Mockito.mock(PluginDataHandlerProvider.class);
@@ -167,6 +172,8 @@ public class LangChainClientTest {
     PluginDataHandler changeDataHandler = Mockito.mock(PluginDataHandler.class);
     String conversationKey =
         OpenAiConversation.getMultiAgentConversationKey(ReviewAssistantStage.REVIEW_CODE);
+    when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_DISABLED))
+        .thenReturn("false");
     when(changeDataHandler.getValue(conversationKey)).thenReturn("conv_review_code");
     PluginDataHandlerProvider pluginDataHandlerProvider = Mockito.mock(PluginDataHandlerProvider.class);
     when(pluginDataHandlerProvider.getChangeScope()).thenReturn(changeDataHandler);
@@ -195,6 +202,76 @@ public class LangChainClientTest {
             changeSetData);
 
     assertEquals(null, conversationId);
+  }
+
+  @Test
+  public void resolvesNoConversationWhenOpenAiConversationIsDisabled() throws Exception {
+    PluginDataHandler changeDataHandler = Mockito.mock(PluginDataHandler.class);
+    when(changeDataHandler.getValue(OpenAiConversation.KEY_CONVERSATION_DISABLED))
+        .thenReturn("true");
+    PluginDataHandlerProvider pluginDataHandlerProvider = Mockito.mock(PluginDataHandlerProvider.class);
+    when(pluginDataHandlerProvider.getChangeScope()).thenReturn(changeDataHandler);
+    ChangeSetData changeSetData = new ChangeSetData(1, -1, 1);
+    changeSetData.setReviewAssistantStage(null);
+
+    String conversationId =
+        resolveConversationId(
+            new LangChainClient(
+                Mockito.mock(Configuration.class), null, null, null, pluginDataHandlerProvider),
+            AiProviderType.OPENAI,
+            changeSetData);
+
+    assertNull(conversationId);
+  }
+
+  @Test
+  public void retriesWithoutConversationForZeroDataRetentionConversationError() {
+    TestableLangChainClient client = new TestableLangChainClient();
+
+    boolean shouldRetry =
+        client.shouldRetryWithoutConversation(
+            AiProviderType.OPENAI,
+            "conv_123",
+            new RuntimeException(
+                "status=400 code=unsupported_parameter type=invalid_request_error "
+                    + "param=conversation body={message=Conversation ID cannot be used for this "
+                    + "organization due to Zero Data Retention.}"));
+
+    assertTrue(shouldRetry);
+  }
+
+  @Test
+  public void doesNotRetryWithoutConversationForNonOpenAiProvider() {
+    TestableLangChainClient client = new TestableLangChainClient();
+
+    boolean shouldRetry =
+        client.shouldRetryWithoutConversation(
+            AiProviderType.GEMINI,
+            "conv_123",
+            new RuntimeException(
+                "status=400 code=unsupported_parameter type=invalid_request_error "
+                    + "param=conversation body={message=Conversation ID cannot be used for this "
+                    + "organization due to Zero Data Retention.}"));
+
+    assertFalse(shouldRetry);
+  }
+
+  @Test
+  public void clearsStageSpecificConversationKeyWhenFallbackIsNeeded() {
+    PluginDataHandler changeDataHandler = Mockito.mock(PluginDataHandler.class);
+    PluginDataHandlerProvider pluginDataHandlerProvider = Mockito.mock(PluginDataHandlerProvider.class);
+    when(pluginDataHandlerProvider.getChangeScope()).thenReturn(changeDataHandler);
+    ChangeSetData changeSetData = new ChangeSetData(1, -1, 1);
+    changeSetData.setReviewAssistantStage(ReviewAssistantStage.REVIEW_CODE);
+
+    TestableLangChainClient client =
+        new TestableLangChainClient(
+            Mockito.mock(Configuration.class), pluginDataHandlerProvider);
+    client.clearResolvedConversationId(changeSetData);
+
+    verify(changeDataHandler).setValue(OpenAiConversation.KEY_CONVERSATION_DISABLED, "true");
+    verify(changeDataHandler)
+        .removeValue(OpenAiConversation.getMultiAgentConversationKey(ReviewAssistantStage.REVIEW_CODE));
   }
 
   @Test
@@ -314,6 +391,12 @@ public class LangChainClientTest {
       super(null, null, null, null);
     }
 
+    private TestableLangChainClient(
+        Configuration config,
+        PluginDataHandlerProvider pluginDataHandlerProvider) {
+      super(config, null, null, null, pluginDataHandlerProvider);
+    }
+
     private AiResponseContent parseResponseContent(String responseText) {
       return toResponseContent(responseText);
     }
@@ -333,6 +416,15 @@ public class LangChainClientTest {
           existingConversation,
           changeSetData,
           change);
+    }
+
+    protected boolean shouldRetryWithoutConversation(
+        AiProviderType providerType, String conversationId, Throwable throwable) {
+      return super.shouldRetryWithoutConversation(providerType, conversationId, throwable);
+    }
+
+    protected void clearResolvedConversationId(ChangeSetData changeSetData) {
+      super.clearResolvedConversationId(changeSetData);
     }
   }
 }


### PR DESCRIPTION
Not sure if this is useful, but I spent a chunk of time with Codex today (I am very much not a Java Developer 😄) looking into #11 and we came up with the following patch.   It detects the error and falls back to using a local memory implemented in an h2 db.

This appears to work in some basic testing in our test gerrit instance running Gerrit 3.13.1, obviously this hasn't been tested with the new AI sidebar implemented in 3.14.x
